### PR TITLE
Make sharing integration test more permissive

### DIFF
--- a/test/integration/workarea/storefront/sharing_integration_test.rb
+++ b/test/integration/workarea/storefront/sharing_integration_test.rb
@@ -32,7 +32,7 @@ module Workarea
         end
 
         assert_includes(email.to, to_email)
-        assert_includes(email.from, Workarea.config.email_from)
+        assert_match(email.from.first, Workarea.config.email_from)
         assert_includes(email.reply_to, from_email)
       end
     end


### PR DESCRIPTION
It was reported that, when Haven Theme is installed in an app, the
`Workarea::Storefront::SharingIntegrationTest` begins to fail. The test
was previously testing if the value of`Workarea.config.email_from`
against an array of defined emails. However, since this configuration
can, and was, being set to a string containing more than just a simple
email address, the test was updated to look for the given email
substring within the configration value.

SHARELINKS-3